### PR TITLE
update 1.0-RC18

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: '1.0-RC17'
+appVersion: '1.0-RC18'
 #appVersion: '1.0-SNAPSHOT'
 description: A Helm chart for Geoserver-cloud
 name: geoservercloud
-version: 0.0.34
+version: 0.0.35
 dependencies:
   - name: 'rabbitmq'
     version: 8.28.1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Helm chart for geoserver-cloud
 
-![Version: 0.0.34](https://img.shields.io/badge/Version-0.0.34-informational?style=flat-square) ![AppVersion: 1.0-RC17](https://img.shields.io/badge/AppVersion-1.0--RC17-informational?style=flat-square)
+![Version: 0.0.35](https://img.shields.io/badge/Version-0.0.35-informational?style=flat-square) ![AppVersion: 1.0-RC18](https://img.shields.io/badge/AppVersion-1.0--RC18-informational?style=flat-square)
 
 A Helm chart for Geoserver
 

--- a/tests/chart/Chart.yaml
+++ b/tests/chart/Chart.yaml
@@ -6,4 +6,4 @@ version: 0.1.0
 dependencies:
   - name: geoservercloud
     repository: file://../..
-    version: 0.0.34
+    version: 0.0.35

--- a/tests/expected.yaml
+++ b/tests/expected.yaml
@@ -20,13 +20,13 @@ kind: ServiceAccount
 metadata:
   name: testwithveryveryverylongreleasename-geoser
   labels:
-    helm.sh/chart: geoservercloud-0.0.34
+    helm.sh/chart: geoservercloud-0.0.35
     deployed_by: helm
     app.kubernetes.io/app_environment: "master"
     app.kubernetes.io/base_environment: "dev"
     app.kubernetes.io/name: geoservercloud
     app.kubernetes.io/instance: testwithveryveryverylongreleasename
-    app.kubernetes.io/version: "1.0-RC17"
+    app.kubernetes.io/version: "1.0-RC18"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: ogscloud/charts/geoservercloud/templates/secrets/secret_postgres.yaml
@@ -93,13 +93,13 @@ kind: ConfigMap
 metadata:
   name: testwithveryveryverylongreleasename-geoser-config-configs
   labels:
-    helm.sh/chart: geoservercloud-0.0.34
+    helm.sh/chart: geoservercloud-0.0.35
     deployed_by: helm
     app.kubernetes.io/app_environment: "master"
     app.kubernetes.io/base_environment: "dev"
     app.kubernetes.io/name: geoservercloud
     app.kubernetes.io/instance: testwithveryveryverylongreleasename
-    app.kubernetes.io/version: "1.0-RC17"
+    app.kubernetes.io/version: "1.0-RC18"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "config"
 data:
@@ -391,6 +391,9 @@ data:
 
     # GeoServer-Cloud common config properties
     geoserver:
+      metrics:
+        enabled: true
+        instance-id: ${info.instance-id}
       security:
         enabled: true
         authkey: true
@@ -730,13 +733,13 @@ kind: Service
 metadata:
   name: testwithveryveryverylongreleasename-geoser-gateway
   labels:
-    helm.sh/chart: geoservercloud-0.0.34
+    helm.sh/chart: geoservercloud-0.0.35
     deployed_by: helm
     app.kubernetes.io/app_environment: "master"
     app.kubernetes.io/base_environment: "dev"
     app.kubernetes.io/name: geoservercloud
     app.kubernetes.io/instance: testwithveryveryverylongreleasename
-    app.kubernetes.io/version: "1.0-RC17"
+    app.kubernetes.io/version: "1.0-RC18"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: gateway
   annotations:
@@ -760,13 +763,13 @@ kind: Service
 metadata:
   name: testwithveryveryverylongreleasename-geoser-gwc
   labels:
-    helm.sh/chart: geoservercloud-0.0.34
+    helm.sh/chart: geoservercloud-0.0.35
     deployed_by: helm
     app.kubernetes.io/app_environment: "master"
     app.kubernetes.io/base_environment: "dev"
     app.kubernetes.io/name: geoservercloud
     app.kubernetes.io/instance: testwithveryveryverylongreleasename
-    app.kubernetes.io/version: "1.0-RC17"
+    app.kubernetes.io/version: "1.0-RC18"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: gwc
 spec:
@@ -789,13 +792,13 @@ kind: Service
 metadata:
   name: testwithveryveryverylongreleasename-geoser-rest
   labels:
-    helm.sh/chart: geoservercloud-0.0.34
+    helm.sh/chart: geoservercloud-0.0.35
     deployed_by: helm
     app.kubernetes.io/app_environment: "master"
     app.kubernetes.io/base_environment: "dev"
     app.kubernetes.io/name: geoservercloud
     app.kubernetes.io/instance: testwithveryveryverylongreleasename
-    app.kubernetes.io/version: "1.0-RC17"
+    app.kubernetes.io/version: "1.0-RC18"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: rest
 spec:
@@ -818,13 +821,13 @@ kind: Service
 metadata:
   name: testwithveryveryverylongreleasename-geoser-wcs
   labels:
-    helm.sh/chart: geoservercloud-0.0.34
+    helm.sh/chart: geoservercloud-0.0.35
     deployed_by: helm
     app.kubernetes.io/app_environment: "master"
     app.kubernetes.io/base_environment: "dev"
     app.kubernetes.io/name: geoservercloud
     app.kubernetes.io/instance: testwithveryveryverylongreleasename
-    app.kubernetes.io/version: "1.0-RC17"
+    app.kubernetes.io/version: "1.0-RC18"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: wcs
 spec:
@@ -847,13 +850,13 @@ kind: Service
 metadata:
   name: testwithveryveryverylongreleasename-geoser-webui
   labels:
-    helm.sh/chart: geoservercloud-0.0.34
+    helm.sh/chart: geoservercloud-0.0.35
     deployed_by: helm
     app.kubernetes.io/app_environment: "master"
     app.kubernetes.io/base_environment: "dev"
     app.kubernetes.io/name: geoservercloud
     app.kubernetes.io/instance: testwithveryveryverylongreleasename
-    app.kubernetes.io/version: "1.0-RC17"
+    app.kubernetes.io/version: "1.0-RC18"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: webui
   annotations:
@@ -878,13 +881,13 @@ kind: Service
 metadata:
   name: testwithveryveryverylongreleasename-geoser-wfs
   labels:
-    helm.sh/chart: geoservercloud-0.0.34
+    helm.sh/chart: geoservercloud-0.0.35
     deployed_by: helm
     app.kubernetes.io/app_environment: "master"
     app.kubernetes.io/base_environment: "dev"
     app.kubernetes.io/name: geoservercloud
     app.kubernetes.io/instance: testwithveryveryverylongreleasename
-    app.kubernetes.io/version: "1.0-RC17"
+    app.kubernetes.io/version: "1.0-RC18"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: wfs
 spec:
@@ -907,13 +910,13 @@ kind: Service
 metadata:
   name: testwithveryveryverylongreleasename-geoser-wms
   labels:
-    helm.sh/chart: geoservercloud-0.0.34
+    helm.sh/chart: geoservercloud-0.0.35
     deployed_by: helm
     app.kubernetes.io/app_environment: "master"
     app.kubernetes.io/base_environment: "dev"
     app.kubernetes.io/name: geoservercloud
     app.kubernetes.io/instance: testwithveryveryverylongreleasename
-    app.kubernetes.io/version: "1.0-RC17"
+    app.kubernetes.io/version: "1.0-RC18"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: wms
 spec:
@@ -935,13 +938,13 @@ kind: Deployment
 metadata:
   name: testwithveryveryverylongreleasename-geoser-gateway
   labels:
-    helm.sh/chart: geoservercloud-0.0.34
+    helm.sh/chart: geoservercloud-0.0.35
     deployed_by: helm
     app.kubernetes.io/app_environment: "master"
     app.kubernetes.io/base_environment: "dev"
     app.kubernetes.io/name: geoservercloud
     app.kubernetes.io/instance: testwithveryveryverylongreleasename
-    app.kubernetes.io/version: "1.0-RC17"
+    app.kubernetes.io/version: "1.0-RC18"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: gateway
   annotations:
@@ -957,7 +960,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e8698e23612264f70811f584df575fc8456240e536039c77f245c63186547845
+        checksum/config: e5cf5fb3442331bd8abe99459c54e2abe033602b443bb80c14921546362bf02c
         specificValues/sha256: e8bd46520d20c5e2dfdb553d200fdd7607a59c6110a8581d5948360a7a12993e
         globalValues/sha256: 130a2567c866307fcd6950b0976112984d2fac6b38c6e55b0a07b3ae8a866247
       labels:
@@ -989,7 +992,7 @@ spec:
         - name: geoservercloud-gateway
           securityContext:
             {}
-          image: "sanitize.me/geoservercloud/geoserver-cloud-gateway:1.0-RC17"
+          image: "sanitize.me/geoservercloud/geoserver-cloud-gateway:1.0-RC18"
           imagePullPolicy: IfNotPresent
           env:
             - name: TARGETS_WMS
@@ -1079,13 +1082,13 @@ kind: Deployment
 metadata:
   name: testwithveryveryverylongreleasename-geoser-gwc
   labels:
-    helm.sh/chart: geoservercloud-0.0.34
+    helm.sh/chart: geoservercloud-0.0.35
     deployed_by: helm
     app.kubernetes.io/app_environment: "master"
     app.kubernetes.io/base_environment: "dev"
     app.kubernetes.io/name: geoservercloud
     app.kubernetes.io/instance: testwithveryveryverylongreleasename
-    app.kubernetes.io/version: "1.0-RC17"
+    app.kubernetes.io/version: "1.0-RC18"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: gwc
 spec:
@@ -1100,7 +1103,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e8698e23612264f70811f584df575fc8456240e536039c77f245c63186547845
+        checksum/config: e5cf5fb3442331bd8abe99459c54e2abe033602b443bb80c14921546362bf02c
         specificValues/sha256: a9690740264bb9e2309fedbd26ad898f336f5321e9fe023626470d1c3f8c3682
         globalValues/sha256: 130a2567c866307fcd6950b0976112984d2fac6b38c6e55b0a07b3ae8a866247
       labels:
@@ -1137,7 +1140,7 @@ spec:
         - name: gwc
           securityContext:
             {}
-          image: "sanitize.me/geoservercloud/geoserver-cloud-gwc:1.0-RC17"
+          image: "sanitize.me/geoservercloud/geoserver-cloud-gwc:1.0-RC18"
           imagePullPolicy: IfNotPresent
           env:
             - name: SPRING_PROFILES_ACTIVE
@@ -1215,13 +1218,13 @@ kind: Deployment
 metadata:
   name: testwithveryveryverylongreleasename-geoser-rest
   labels:
-    helm.sh/chart: geoservercloud-0.0.34
+    helm.sh/chart: geoservercloud-0.0.35
     deployed_by: helm
     app.kubernetes.io/app_environment: "master"
     app.kubernetes.io/base_environment: "dev"
     app.kubernetes.io/name: geoservercloud
     app.kubernetes.io/instance: testwithveryveryverylongreleasename
-    app.kubernetes.io/version: "1.0-RC17"
+    app.kubernetes.io/version: "1.0-RC18"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: rest
 spec:
@@ -1236,7 +1239,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e8698e23612264f70811f584df575fc8456240e536039c77f245c63186547845
+        checksum/config: e5cf5fb3442331bd8abe99459c54e2abe033602b443bb80c14921546362bf02c
         specificValues/sha256: 1df2cc19cf6772f2cd4bc4fe41bf77ab7b212de9547481ee68995c51b45c7350
         globalValues/sha256: 130a2567c866307fcd6950b0976112984d2fac6b38c6e55b0a07b3ae8a866247
       labels:
@@ -1273,7 +1276,7 @@ spec:
         - name: rest
           securityContext:
             {}
-          image: "sanitize.me/geoservercloud/geoserver-cloud-rest:1.0-RC17"
+          image: "sanitize.me/geoservercloud/geoserver-cloud-rest:1.0-RC18"
           imagePullPolicy: IfNotPresent
           env:
             - name: SPRING_PROFILES_ACTIVE
@@ -1351,13 +1354,13 @@ kind: Deployment
 metadata:
   name: testwithveryveryverylongreleasename-geoser-wcs
   labels:
-    helm.sh/chart: geoservercloud-0.0.34
+    helm.sh/chart: geoservercloud-0.0.35
     deployed_by: helm
     app.kubernetes.io/app_environment: "master"
     app.kubernetes.io/base_environment: "dev"
     app.kubernetes.io/name: geoservercloud
     app.kubernetes.io/instance: testwithveryveryverylongreleasename
-    app.kubernetes.io/version: "1.0-RC17"
+    app.kubernetes.io/version: "1.0-RC18"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: wcs
 spec:
@@ -1372,7 +1375,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e8698e23612264f70811f584df575fc8456240e536039c77f245c63186547845
+        checksum/config: e5cf5fb3442331bd8abe99459c54e2abe033602b443bb80c14921546362bf02c
         specificValues/sha256: 8862be7440511b1889f3724370edc912e1615b3edfc346122a7cb70edfc70654
         globalValues/sha256: 130a2567c866307fcd6950b0976112984d2fac6b38c6e55b0a07b3ae8a866247
       labels:
@@ -1409,7 +1412,7 @@ spec:
         - name: wcs
           securityContext:
             {}
-          image: "sanitize.me/geoservercloud/geoserver-cloud-wcs:1.0-RC17"
+          image: "sanitize.me/geoservercloud/geoserver-cloud-wcs:1.0-RC18"
           imagePullPolicy: IfNotPresent
           env:
             - name: SPRING_PROFILES_ACTIVE
@@ -1487,13 +1490,13 @@ kind: Deployment
 metadata:
   name: testwithveryveryverylongreleasename-geoser-webui
   labels:
-    helm.sh/chart: geoservercloud-0.0.34
+    helm.sh/chart: geoservercloud-0.0.35
     deployed_by: helm
     app.kubernetes.io/app_environment: "master"
     app.kubernetes.io/base_environment: "dev"
     app.kubernetes.io/name: geoservercloud
     app.kubernetes.io/instance: testwithveryveryverylongreleasename
-    app.kubernetes.io/version: "1.0-RC17"
+    app.kubernetes.io/version: "1.0-RC18"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: webui
   annotations:
@@ -1510,7 +1513,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e8698e23612264f70811f584df575fc8456240e536039c77f245c63186547845
+        checksum/config: e5cf5fb3442331bd8abe99459c54e2abe033602b443bb80c14921546362bf02c
         specificValues/sha256: 0a4ad591b6dae7d9aaad1927ae7716c473fedd10af8dd6dea047850f24407186
         globalValues/sha256: 130a2567c866307fcd6950b0976112984d2fac6b38c6e55b0a07b3ae8a866247
       labels:
@@ -1547,7 +1550,7 @@ spec:
         - name: webui
           securityContext:
             {}
-          image: "sanitize.me/geoservercloud/geoserver-cloud-webui:1.0-RC17"
+          image: "sanitize.me/geoservercloud/geoserver-cloud-webui:1.0-RC18"
           imagePullPolicy: IfNotPresent
           env:
             - name: SPRING_PROFILES_ACTIVE
@@ -1625,13 +1628,13 @@ kind: Deployment
 metadata:
   name: testwithveryveryverylongreleasename-geoser-wfs
   labels:
-    helm.sh/chart: geoservercloud-0.0.34
+    helm.sh/chart: geoservercloud-0.0.35
     deployed_by: helm
     app.kubernetes.io/app_environment: "master"
     app.kubernetes.io/base_environment: "dev"
     app.kubernetes.io/name: geoservercloud
     app.kubernetes.io/instance: testwithveryveryverylongreleasename
-    app.kubernetes.io/version: "1.0-RC17"
+    app.kubernetes.io/version: "1.0-RC18"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: wfs
 spec:
@@ -1646,7 +1649,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e8698e23612264f70811f584df575fc8456240e536039c77f245c63186547845
+        checksum/config: e5cf5fb3442331bd8abe99459c54e2abe033602b443bb80c14921546362bf02c
         specificValues/sha256: 57cfdc1dc38052d83e3c54ba9151b795a5a7aa4e9f3539cda14be2c82258ed09
         globalValues/sha256: 130a2567c866307fcd6950b0976112984d2fac6b38c6e55b0a07b3ae8a866247
       labels:
@@ -1683,7 +1686,7 @@ spec:
         - name: wfs
           securityContext:
             {}
-          image: "sanitize.me/geoservercloud/geoserver-cloud-wfs:1.0-RC17"
+          image: "sanitize.me/geoservercloud/geoserver-cloud-wfs:1.0-RC18"
           imagePullPolicy: IfNotPresent
           env:
             - name: SPRING_PROFILES_ACTIVE
@@ -1761,13 +1764,13 @@ kind: Deployment
 metadata:
   name: testwithveryveryverylongreleasename-geoser-wms
   labels:
-    helm.sh/chart: geoservercloud-0.0.34
+    helm.sh/chart: geoservercloud-0.0.35
     deployed_by: helm
     app.kubernetes.io/app_environment: "master"
     app.kubernetes.io/base_environment: "dev"
     app.kubernetes.io/name: geoservercloud
     app.kubernetes.io/instance: testwithveryveryverylongreleasename
-    app.kubernetes.io/version: "1.0-RC17"
+    app.kubernetes.io/version: "1.0-RC18"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: wms
 spec:
@@ -1782,7 +1785,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e8698e23612264f70811f584df575fc8456240e536039c77f245c63186547845
+        checksum/config: e5cf5fb3442331bd8abe99459c54e2abe033602b443bb80c14921546362bf02c
         specificValues/sha256: 200a01537285002addd55515b8da6293fc56f77cb7c6230512694ae1ef903985
         globalValues/sha256: 130a2567c866307fcd6950b0976112984d2fac6b38c6e55b0a07b3ae8a866247
       labels:
@@ -1819,7 +1822,7 @@ spec:
         - name: wms
           securityContext:
             {}
-          image: "sanitize.me/geoservercloud/geoserver-cloud-wms:1.0-RC17"
+          image: "sanitize.me/geoservercloud/geoserver-cloud-wms:1.0-RC18"
           imagePullPolicy: IfNotPresent
           env:
             - name: SPRING_PROFILES_ACTIVE


### PR DESCRIPTION
key feature of update 1.0-rc18 is that it adds the internal metrics for the config. e.g. it is possible to follow the config updateSequence evolution of each pod to see if it is in sync with webui/rest-config like so:
```bash
k exec -it geoserver-geoservercloud-wms-f96bd48d7-pcmdz -- curl localhost:8081/actuator/metrics/geoserver.config.update_sequence | jq ''
{
  "name": "geoserver.config.update_sequence",
  "description": "GeoServer configuration update sequence",
  "baseUnit": "sequence",
  "measurements": [
    {
      "statistic": "VALUE",
      "value": 9
    }
  ],
  "availableTags": [
    {
      "tag": "instance-id",
      "values": [
        "wms-service:10.42.0.52:8080"
      ]
    }
  ]
}

```
