### PR TITLE
Remove namespace from pvc

### DIFF
--- a/examples/common/templates/pv_pvc.yaml
+++ b/examples/common/templates/pv_pvc.yaml
@@ -23,7 +23,6 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{$definition.pvcname}}
-  namespace: default
 spec:
   accessModes:
     - ReadWriteMany


### PR DESCRIPTION
Having the hardcoded namespace in the pvc will create failures when deployed in different namespaces. Removing this allows users to use `helm upgrade --install .... --create-namespace --namespace=geoserver`
This makes the entire deployment more flexible
