### PR TITLE
Upgrade gscloud 1.8.0 -> 1.8.1

### DIFF
--- a/tests/expected-datadir.yaml
+++ b/tests/expected-datadir.yaml
@@ -158,21 +158,21 @@ data:
   SERVICE_ACL_NAME: gs-cloud-datadir-gsc-acl
   SERVICE_ACL_CONTAINER_SPRING_IMAGE_TAG: "2.2.0"
   SERVICE_GATEWAY_NAME: gs-cloud-datadir-gsc-gateway
-  SERVICE_GATEWAY_CONTAINER_SPRING_IMAGE_TAG: "1.8.0"
+  SERVICE_GATEWAY_CONTAINER_SPRING_IMAGE_TAG: "1.8.1"
   SERVICE_GWC_NAME: gs-cloud-datadir-gsc-gwc
-  SERVICE_GWC_CONTAINER_SPRING_IMAGE_TAG: "1.8.0"
+  SERVICE_GWC_CONTAINER_SPRING_IMAGE_TAG: "1.8.1"
   SERVICE_REST_NAME: gs-cloud-datadir-gsc-rest
-  SERVICE_REST_CONTAINER_SPRING_IMAGE_TAG: "1.8.0"
+  SERVICE_REST_CONTAINER_SPRING_IMAGE_TAG: "1.8.1"
   SERVICE_WCS_NAME: gs-cloud-datadir-gsc-wcs
-  SERVICE_WCS_CONTAINER_SPRING_IMAGE_TAG: "1.8.0"
+  SERVICE_WCS_CONTAINER_SPRING_IMAGE_TAG: "1.8.1"
   SERVICE_WEBUI_NAME: gs-cloud-datadir-gsc-webui
-  SERVICE_WEBUI_CONTAINER_SPRING_IMAGE_TAG: "1.8.0"
+  SERVICE_WEBUI_CONTAINER_SPRING_IMAGE_TAG: "1.8.1"
   SERVICE_WFS_NAME: gs-cloud-datadir-gsc-wfs
-  SERVICE_WFS_CONTAINER_SPRING_IMAGE_TAG: "1.8.0"
+  SERVICE_WFS_CONTAINER_SPRING_IMAGE_TAG: "1.8.1"
   SERVICE_WMS_NAME: gs-cloud-datadir-gsc-wms
-  SERVICE_WMS_CONTAINER_SPRING_IMAGE_TAG: "1.8.0"
+  SERVICE_WMS_CONTAINER_SPRING_IMAGE_TAG: "1.8.1"
   SERVICE_WPS_NAME: gs-cloud-datadir-gsc-wps
-  SERVICE_WPS_CONTAINER_SPRING_IMAGE_TAG: "1.8.0"
+  SERVICE_WPS_CONTAINER_SPRING_IMAGE_TAG: "1.8.1"
 ---
 # Source: gs-cloud-datadir/charts/geoservercloud/charts/geoserver/templates/service.yaml
 apiVersion: v1
@@ -382,7 +382,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-gateway:1.8.0"
+          image: "geoservercloud/geoserver-cloud-gateway:1.8.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -578,7 +578,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-gwc:1.8.0"
+          image: "geoservercloud/geoserver-cloud-gwc:1.8.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -774,7 +774,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-rest:1.8.0"
+          image: "geoservercloud/geoserver-cloud-rest:1.8.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -970,7 +970,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-wcs:1.8.0"
+          image: "geoservercloud/geoserver-cloud-wcs:1.8.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -1166,7 +1166,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-webui:1.8.0"
+          image: "geoservercloud/geoserver-cloud-webui:1.8.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -1362,7 +1362,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-wfs:1.8.0"
+          image: "geoservercloud/geoserver-cloud-wfs:1.8.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -1558,7 +1558,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-wms:1.8.0"
+          image: "geoservercloud/geoserver-cloud-wms:1.8.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"

--- a/tests/expected-jdbc.yaml
+++ b/tests/expected-jdbc.yaml
@@ -173,21 +173,21 @@ data:
   SERVICE_ACL_NAME: gs-cloud-jdbc-gsc-acl
   SERVICE_ACL_CONTAINER_SPRING_IMAGE_TAG: "2.2.0"
   SERVICE_GATEWAY_NAME: gs-cloud-jdbc-gsc-gateway
-  SERVICE_GATEWAY_CONTAINER_SPRING_IMAGE_TAG: "1.8.0"
+  SERVICE_GATEWAY_CONTAINER_SPRING_IMAGE_TAG: "1.8.1"
   SERVICE_GWC_NAME: gs-cloud-jdbc-gsc-gwc
-  SERVICE_GWC_CONTAINER_SPRING_IMAGE_TAG: "1.8.0"
+  SERVICE_GWC_CONTAINER_SPRING_IMAGE_TAG: "1.8.1"
   SERVICE_REST_NAME: gs-cloud-jdbc-gsc-rest
-  SERVICE_REST_CONTAINER_SPRING_IMAGE_TAG: "1.8.0"
+  SERVICE_REST_CONTAINER_SPRING_IMAGE_TAG: "1.8.1"
   SERVICE_WCS_NAME: gs-cloud-jdbc-gsc-wcs
-  SERVICE_WCS_CONTAINER_SPRING_IMAGE_TAG: "1.8.0"
+  SERVICE_WCS_CONTAINER_SPRING_IMAGE_TAG: "1.8.1"
   SERVICE_WEBUI_NAME: gs-cloud-jdbc-gsc-webui
-  SERVICE_WEBUI_CONTAINER_SPRING_IMAGE_TAG: "1.8.0"
+  SERVICE_WEBUI_CONTAINER_SPRING_IMAGE_TAG: "1.8.1"
   SERVICE_WFS_NAME: gs-cloud-jdbc-gsc-wfs
-  SERVICE_WFS_CONTAINER_SPRING_IMAGE_TAG: "1.8.0"
+  SERVICE_WFS_CONTAINER_SPRING_IMAGE_TAG: "1.8.1"
   SERVICE_WMS_NAME: gs-cloud-jdbc-gsc-wms
-  SERVICE_WMS_CONTAINER_SPRING_IMAGE_TAG: "1.8.0"
+  SERVICE_WMS_CONTAINER_SPRING_IMAGE_TAG: "1.8.1"
   SERVICE_WPS_NAME: gs-cloud-jdbc-gsc-wps
-  SERVICE_WPS_CONTAINER_SPRING_IMAGE_TAG: "1.8.0"
+  SERVICE_WPS_CONTAINER_SPRING_IMAGE_TAG: "1.8.1"
 ---
 # Source: gs-cloud-jdbc/charts/geoservercloud/charts/geoserver/templates/service.yaml
 apiVersion: v1
@@ -394,7 +394,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-gateway:1.8.0"
+          image: "geoservercloud/geoserver-cloud-gateway:1.8.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -615,7 +615,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-gwc:1.8.0"
+          image: "geoservercloud/geoserver-cloud-gwc:1.8.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -836,7 +836,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-rest:1.8.0"
+          image: "geoservercloud/geoserver-cloud-rest:1.8.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -1057,7 +1057,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-wcs:1.8.0"
+          image: "geoservercloud/geoserver-cloud-wcs:1.8.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -1278,7 +1278,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-webui:1.8.0"
+          image: "geoservercloud/geoserver-cloud-webui:1.8.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -1499,7 +1499,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-wfs:1.8.0"
+          image: "geoservercloud/geoserver-cloud-wfs:1.8.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -1720,7 +1720,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-wms:1.8.0"
+          image: "geoservercloud/geoserver-cloud-wms:1.8.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"

--- a/tests/expected-pgconfig-acl.yaml
+++ b/tests/expected-pgconfig-acl.yaml
@@ -302,21 +302,21 @@ data:
   SERVICE_ACL_NAME: gs-cloud-pgconfig-acl-gsc-acl
   SERVICE_ACL_CONTAINER_SPRING_IMAGE_TAG: "2.2.0"
   SERVICE_GATEWAY_NAME: gs-cloud-pgconfig-acl-gsc-gateway
-  SERVICE_GATEWAY_CONTAINER_SPRING_IMAGE_TAG: "1.8.0"
+  SERVICE_GATEWAY_CONTAINER_SPRING_IMAGE_TAG: "1.8.1"
   SERVICE_GWC_NAME: gs-cloud-pgconfig-acl-gsc-gwc
-  SERVICE_GWC_CONTAINER_SPRING_IMAGE_TAG: "1.8.0"
+  SERVICE_GWC_CONTAINER_SPRING_IMAGE_TAG: "1.8.1"
   SERVICE_REST_NAME: gs-cloud-pgconfig-acl-gsc-rest
-  SERVICE_REST_CONTAINER_SPRING_IMAGE_TAG: "1.8.0"
+  SERVICE_REST_CONTAINER_SPRING_IMAGE_TAG: "1.8.1"
   SERVICE_WCS_NAME: gs-cloud-pgconfig-acl-gsc-wcs
-  SERVICE_WCS_CONTAINER_SPRING_IMAGE_TAG: "1.8.0"
+  SERVICE_WCS_CONTAINER_SPRING_IMAGE_TAG: "1.8.1"
   SERVICE_WEBUI_NAME: gs-cloud-pgconfig-acl-gsc-webui
-  SERVICE_WEBUI_CONTAINER_SPRING_IMAGE_TAG: "1.8.0"
+  SERVICE_WEBUI_CONTAINER_SPRING_IMAGE_TAG: "1.8.1"
   SERVICE_WFS_NAME: gs-cloud-pgconfig-acl-gsc-wfs
-  SERVICE_WFS_CONTAINER_SPRING_IMAGE_TAG: "1.8.0"
+  SERVICE_WFS_CONTAINER_SPRING_IMAGE_TAG: "1.8.1"
   SERVICE_WMS_NAME: gs-cloud-pgconfig-acl-gsc-wms
-  SERVICE_WMS_CONTAINER_SPRING_IMAGE_TAG: "1.8.0"
+  SERVICE_WMS_CONTAINER_SPRING_IMAGE_TAG: "1.8.1"
   SERVICE_WPS_NAME: gs-cloud-pgconfig-acl-gsc-wps
-  SERVICE_WPS_CONTAINER_SPRING_IMAGE_TAG: "1.8.0"
+  SERVICE_WPS_CONTAINER_SPRING_IMAGE_TAG: "1.8.1"
 ---
 # Source: gs-cloud-pgconfig/templates/geoserver-pgconfig-cm.yml
 apiVersion: v1
@@ -780,7 +780,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-gateway:1.8.0"
+          image: "geoservercloud/geoserver-cloud-gateway:1.8.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_PASSWORD"
@@ -991,7 +991,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-gwc:1.8.0"
+          image: "geoservercloud/geoserver-cloud-gwc:1.8.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_PASSWORD"
@@ -1203,7 +1203,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-rest:1.8.0"
+          image: "geoservercloud/geoserver-cloud-rest:1.8.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_PASSWORD"
@@ -1415,7 +1415,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-wcs:1.8.0"
+          image: "geoservercloud/geoserver-cloud-wcs:1.8.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_PASSWORD"
@@ -1627,7 +1627,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-webui:1.8.0"
+          image: "geoservercloud/geoserver-cloud-webui:1.8.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_PASSWORD"
@@ -1839,7 +1839,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-wfs:1.8.0"
+          image: "geoservercloud/geoserver-cloud-wfs:1.8.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_PASSWORD"
@@ -2051,7 +2051,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-wms:1.8.0"
+          image: "geoservercloud/geoserver-cloud-wms:1.8.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_PASSWORD"
@@ -2263,7 +2263,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-wps:1.8.0"
+          image: "geoservercloud/geoserver-cloud-wps:1.8.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_PASSWORD"

--- a/tests/expected-statefulset.yaml
+++ b/tests/expected-statefulset.yaml
@@ -158,21 +158,21 @@ data:
   SERVICE_ACL_NAME: gs-cloud-statefulset-gsc-acl
   SERVICE_ACL_CONTAINER_SPRING_IMAGE_TAG: "2.2.0"
   SERVICE_GATEWAY_NAME: gs-cloud-statefulset-gsc-gateway
-  SERVICE_GATEWAY_CONTAINER_SPRING_IMAGE_TAG: "1.8.0"
+  SERVICE_GATEWAY_CONTAINER_SPRING_IMAGE_TAG: "1.8.1"
   SERVICE_GWC_NAME: gs-cloud-statefulset-gsc-gwc
-  SERVICE_GWC_CONTAINER_SPRING_IMAGE_TAG: "1.8.0"
+  SERVICE_GWC_CONTAINER_SPRING_IMAGE_TAG: "1.8.1"
   SERVICE_REST_NAME: gs-cloud-statefulset-gsc-rest
-  SERVICE_REST_CONTAINER_SPRING_IMAGE_TAG: "1.8.0"
+  SERVICE_REST_CONTAINER_SPRING_IMAGE_TAG: "1.8.1"
   SERVICE_WCS_NAME: gs-cloud-statefulset-gsc-wcs
-  SERVICE_WCS_CONTAINER_SPRING_IMAGE_TAG: "1.8.0"
+  SERVICE_WCS_CONTAINER_SPRING_IMAGE_TAG: "1.8.1"
   SERVICE_WEBUI_NAME: gs-cloud-statefulset-gsc-webui
-  SERVICE_WEBUI_CONTAINER_SPRING_IMAGE_TAG: "1.8.0"
+  SERVICE_WEBUI_CONTAINER_SPRING_IMAGE_TAG: "1.8.1"
   SERVICE_WFS_NAME: gs-cloud-statefulset-gsc-wfs
-  SERVICE_WFS_CONTAINER_SPRING_IMAGE_TAG: "1.8.0"
+  SERVICE_WFS_CONTAINER_SPRING_IMAGE_TAG: "1.8.1"
   SERVICE_WMS_NAME: gs-cloud-statefulset-gsc-wms
-  SERVICE_WMS_CONTAINER_SPRING_IMAGE_TAG: "1.8.0"
+  SERVICE_WMS_CONTAINER_SPRING_IMAGE_TAG: "1.8.1"
   SERVICE_WPS_NAME: gs-cloud-statefulset-gsc-wps
-  SERVICE_WPS_CONTAINER_SPRING_IMAGE_TAG: "1.8.0"
+  SERVICE_WPS_CONTAINER_SPRING_IMAGE_TAG: "1.8.1"
 ---
 # Source: gs-cloud-statefulset/charts/geoservercloud/charts/geoserver/templates/service.yaml
 apiVersion: v1
@@ -382,7 +382,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-gateway:1.8.0"
+          image: "geoservercloud/geoserver-cloud-gateway:1.8.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -577,7 +577,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-rest:1.8.0"
+          image: "geoservercloud/geoserver-cloud-rest:1.8.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -772,7 +772,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-wcs:1.8.0"
+          image: "geoservercloud/geoserver-cloud-wcs:1.8.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -967,7 +967,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-webui:1.8.0"
+          image: "geoservercloud/geoserver-cloud-webui:1.8.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -1162,7 +1162,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-wfs:1.8.0"
+          image: "geoservercloud/geoserver-cloud-wfs:1.8.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -1357,7 +1357,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-wms:1.8.0"
+          image: "geoservercloud/geoserver-cloud-wms:1.8.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -1562,7 +1562,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-gwc:1.8.0"
+          image: "geoservercloud/geoserver-cloud-gwc:1.8.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"

--- a/values.yaml
+++ b/values.yaml
@@ -3,7 +3,7 @@ podSecurityContext: {}
 securityContext: {}
 
 common-image-stuff: &common-image-stuff
-  tag: '1.8.0'
+  tag: '1.8.1'
 
 service: &common-service-definition
   type: ClusterIP


### PR DESCRIPTION
@jemacchi this upgrades to gsc 1.8.1

It'd be great if you can remove the `geoserver-pgconfig-cm.yml` configmap and use env variables instead to substitute the following default properties (from `/etc/geoserver/geoserver.yml`):

```
pgconfig.host: pgconfigdb
pgconfig.port: 5432
pgconfig.database: pgconfig
pgconfig.schema: pgconfig
pgconfig.username: pgconfig
pgconfig.password: pgconfig
pgconfig.maxConnections: 10
```
