### PR TITLE
Upgrade GSCloud to 2.28.2.0

### DIFF
--- a/tests/expected-datadir.yaml
+++ b/tests/expected-datadir.yaml
@@ -174,21 +174,21 @@ data:
   SERVICE_ACL_NAME: gs-cloud-datadir-gsc-acl
   SERVICE_ACL_CONTAINER_SPRING_IMAGE_TAG: "2.4.0"
   SERVICE_GATEWAY_NAME: gs-cloud-datadir-gsc-gateway
-  SERVICE_GATEWAY_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_GATEWAY_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
   SERVICE_GWC_NAME: gs-cloud-datadir-gsc-gwc
-  SERVICE_GWC_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_GWC_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
   SERVICE_REST_NAME: gs-cloud-datadir-gsc-rest
-  SERVICE_REST_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_REST_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
   SERVICE_WCS_NAME: gs-cloud-datadir-gsc-wcs
-  SERVICE_WCS_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_WCS_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
   SERVICE_WEBUI_NAME: gs-cloud-datadir-gsc-webui
-  SERVICE_WEBUI_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_WEBUI_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
   SERVICE_WFS_NAME: gs-cloud-datadir-gsc-wfs
-  SERVICE_WFS_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_WFS_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
   SERVICE_WMS_NAME: gs-cloud-datadir-gsc-wms
-  SERVICE_WMS_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_WMS_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
   SERVICE_WPS_NAME: gs-cloud-datadir-gsc-wps
-  SERVICE_WPS_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_WPS_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
 ---
 # Source: gs-cloud-datadir/charts/geoservercloud/charts/geoserver/templates/service.yaml
 apiVersion: v1
@@ -400,7 +400,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-gateway:2.28.1.3"
+          image: "geoservercloud/geoserver-cloud-gateway:2.28.2.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -599,7 +599,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-gwc:2.28.1.3"
+          image: "geoservercloud/geoserver-cloud-gwc:2.28.2.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -798,7 +798,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-rest:2.28.1.3"
+          image: "geoservercloud/geoserver-cloud-rest:2.28.2.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -997,7 +997,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-wcs:2.28.1.3"
+          image: "geoservercloud/geoserver-cloud-wcs:2.28.2.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -1196,7 +1196,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-webui:2.28.1.3"
+          image: "geoservercloud/geoserver-cloud-webui:2.28.2.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -1395,7 +1395,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-wfs:2.28.1.3"
+          image: "geoservercloud/geoserver-cloud-wfs:2.28.2.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -1594,7 +1594,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-wms:2.28.1.3"
+          image: "geoservercloud/geoserver-cloud-wms:2.28.2.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"

--- a/tests/expected-jdbc.yaml
+++ b/tests/expected-jdbc.yaml
@@ -189,21 +189,21 @@ data:
   SERVICE_ACL_NAME: gs-cloud-jdbc-gsc-acl
   SERVICE_ACL_CONTAINER_SPRING_IMAGE_TAG: "2.4.0"
   SERVICE_GATEWAY_NAME: gs-cloud-jdbc-gsc-gateway
-  SERVICE_GATEWAY_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_GATEWAY_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
   SERVICE_GWC_NAME: gs-cloud-jdbc-gsc-gwc
-  SERVICE_GWC_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_GWC_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
   SERVICE_REST_NAME: gs-cloud-jdbc-gsc-rest
-  SERVICE_REST_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_REST_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
   SERVICE_WCS_NAME: gs-cloud-jdbc-gsc-wcs
-  SERVICE_WCS_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_WCS_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
   SERVICE_WEBUI_NAME: gs-cloud-jdbc-gsc-webui
-  SERVICE_WEBUI_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_WEBUI_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
   SERVICE_WFS_NAME: gs-cloud-jdbc-gsc-wfs
-  SERVICE_WFS_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_WFS_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
   SERVICE_WMS_NAME: gs-cloud-jdbc-gsc-wms
-  SERVICE_WMS_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_WMS_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
   SERVICE_WPS_NAME: gs-cloud-jdbc-gsc-wps
-  SERVICE_WPS_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_WPS_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
 ---
 # Source: gs-cloud-jdbc/charts/geoservercloud/charts/geoserver/templates/service.yaml
 apiVersion: v1
@@ -412,7 +412,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-gateway:2.28.1.3"
+          image: "geoservercloud/geoserver-cloud-gateway:2.28.2.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -636,7 +636,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-gwc:2.28.1.3"
+          image: "geoservercloud/geoserver-cloud-gwc:2.28.2.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -860,7 +860,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-rest:2.28.1.3"
+          image: "geoservercloud/geoserver-cloud-rest:2.28.2.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -1084,7 +1084,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-wcs:2.28.1.3"
+          image: "geoservercloud/geoserver-cloud-wcs:2.28.2.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -1308,7 +1308,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-webui:2.28.1.3"
+          image: "geoservercloud/geoserver-cloud-webui:2.28.2.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -1532,7 +1532,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-wfs:2.28.1.3"
+          image: "geoservercloud/geoserver-cloud-wfs:2.28.2.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -1756,7 +1756,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-wms:2.28.1.3"
+          image: "geoservercloud/geoserver-cloud-wms:2.28.2.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"

--- a/tests/expected-pgconfig-acl.yaml
+++ b/tests/expected-pgconfig-acl.yaml
@@ -308,21 +308,21 @@ data:
   SERVICE_ACL_NAME: gs-cloud-pgconfig-acl-gsc-acl
   SERVICE_ACL_CONTAINER_SPRING_IMAGE_TAG: "2.4.0"
   SERVICE_GATEWAY_NAME: gs-cloud-pgconfig-acl-gsc-gateway
-  SERVICE_GATEWAY_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_GATEWAY_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
   SERVICE_GWC_NAME: gs-cloud-pgconfig-acl-gsc-gwc
-  SERVICE_GWC_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_GWC_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
   SERVICE_REST_NAME: gs-cloud-pgconfig-acl-gsc-rest
-  SERVICE_REST_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_REST_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
   SERVICE_WCS_NAME: gs-cloud-pgconfig-acl-gsc-wcs
-  SERVICE_WCS_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_WCS_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
   SERVICE_WEBUI_NAME: gs-cloud-pgconfig-acl-gsc-webui
-  SERVICE_WEBUI_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_WEBUI_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
   SERVICE_WFS_NAME: gs-cloud-pgconfig-acl-gsc-wfs
-  SERVICE_WFS_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_WFS_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
   SERVICE_WMS_NAME: gs-cloud-pgconfig-acl-gsc-wms
-  SERVICE_WMS_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_WMS_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
   SERVICE_WPS_NAME: gs-cloud-pgconfig-acl-gsc-wps
-  SERVICE_WPS_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_WPS_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
 ---
 # Source: gs-cloud-pgconfig/templates/install-postgis-cm.yml
 apiVersion: v1
@@ -764,7 +764,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-gateway:2.28.1.3"
+          image: "geoservercloud/geoserver-cloud-gateway:2.28.2.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_PASSWORD"
@@ -985,7 +985,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-gwc:2.28.1.3"
+          image: "geoservercloud/geoserver-cloud-gwc:2.28.2.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_PASSWORD"
@@ -1207,7 +1207,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-rest:2.28.1.3"
+          image: "geoservercloud/geoserver-cloud-rest:2.28.2.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_PASSWORD"
@@ -1429,7 +1429,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-wcs:2.28.1.3"
+          image: "geoservercloud/geoserver-cloud-wcs:2.28.2.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_PASSWORD"
@@ -1651,7 +1651,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-webui:2.28.1.3"
+          image: "geoservercloud/geoserver-cloud-webui:2.28.2.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_PASSWORD"
@@ -1873,7 +1873,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-wfs:2.28.1.3"
+          image: "geoservercloud/geoserver-cloud-wfs:2.28.2.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_PASSWORD"
@@ -2095,7 +2095,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-wms:2.28.1.3"
+          image: "geoservercloud/geoserver-cloud-wms:2.28.2.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_PASSWORD"
@@ -2317,7 +2317,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-wps:2.28.1.3"
+          image: "geoservercloud/geoserver-cloud-wps:2.28.2.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_PASSWORD"

--- a/tests/expected-pgconfig-wms-hpa.yaml
+++ b/tests/expected-pgconfig-wms-hpa.yaml
@@ -194,21 +194,21 @@ data:
   SERVICE_ACL_NAME: gs-cloud-pgconfig-wms-hpa-gsc-acl
   SERVICE_ACL_CONTAINER_SPRING_IMAGE_TAG: "2.4.0"
   SERVICE_GATEWAY_NAME: gs-cloud-pgconfig-wms-hpa-gsc-gateway
-  SERVICE_GATEWAY_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_GATEWAY_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
   SERVICE_GWC_NAME: gs-cloud-pgconfig-wms-hpa-gsc-gwc
-  SERVICE_GWC_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_GWC_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
   SERVICE_REST_NAME: gs-cloud-pgconfig-wms-hpa-gsc-rest
-  SERVICE_REST_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_REST_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
   SERVICE_WCS_NAME: gs-cloud-pgconfig-wms-hpa-gsc-wcs
-  SERVICE_WCS_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_WCS_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
   SERVICE_WEBUI_NAME: gs-cloud-pgconfig-wms-hpa-gsc-webui
-  SERVICE_WEBUI_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_WEBUI_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
   SERVICE_WFS_NAME: gs-cloud-pgconfig-wms-hpa-gsc-wfs
-  SERVICE_WFS_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_WFS_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
   SERVICE_WMS_NAME: gs-cloud-pgconfig-wms-hpa-gsc-wms
-  SERVICE_WMS_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_WMS_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
   SERVICE_WPS_NAME: gs-cloud-pgconfig-wms-hpa-gsc-wps
-  SERVICE_WPS_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_WPS_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
 ---
 # Source: gs-cloud-hpa/charts/geoservercloud/charts/geoserver/templates/service.yaml
 apiVersion: v1
@@ -406,7 +406,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-gateway:2.28.1.3"
+          image: "geoservercloud/geoserver-cloud-gateway:2.28.2.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -615,7 +615,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-rest:2.28.1.3"
+          image: "geoservercloud/geoserver-cloud-rest:2.28.2.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -824,7 +824,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-webui:2.28.1.3"
+          image: "geoservercloud/geoserver-cloud-webui:2.28.2.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -1033,7 +1033,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-wms:2.28.1.3"
+          image: "geoservercloud/geoserver-cloud-wms:2.28.2.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"

--- a/tests/expected-statefulset.yaml
+++ b/tests/expected-statefulset.yaml
@@ -174,21 +174,21 @@ data:
   SERVICE_ACL_NAME: gs-cloud-statefulset-gsc-acl
   SERVICE_ACL_CONTAINER_SPRING_IMAGE_TAG: "2.4.0"
   SERVICE_GATEWAY_NAME: gs-cloud-statefulset-gsc-gateway
-  SERVICE_GATEWAY_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_GATEWAY_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
   SERVICE_GWC_NAME: gs-cloud-statefulset-gsc-gwc
-  SERVICE_GWC_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_GWC_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
   SERVICE_REST_NAME: gs-cloud-statefulset-gsc-rest
-  SERVICE_REST_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_REST_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
   SERVICE_WCS_NAME: gs-cloud-statefulset-gsc-wcs
-  SERVICE_WCS_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_WCS_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
   SERVICE_WEBUI_NAME: gs-cloud-statefulset-gsc-webui
-  SERVICE_WEBUI_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_WEBUI_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
   SERVICE_WFS_NAME: gs-cloud-statefulset-gsc-wfs
-  SERVICE_WFS_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_WFS_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
   SERVICE_WMS_NAME: gs-cloud-statefulset-gsc-wms
-  SERVICE_WMS_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_WMS_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
   SERVICE_WPS_NAME: gs-cloud-statefulset-gsc-wps
-  SERVICE_WPS_CONTAINER_SPRING_IMAGE_TAG: "2.28.1.3"
+  SERVICE_WPS_CONTAINER_SPRING_IMAGE_TAG: "2.28.2.0"
 ---
 # Source: gs-cloud-statefulset/charts/geoservercloud/charts/geoserver/templates/service.yaml
 apiVersion: v1
@@ -400,7 +400,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-gateway:2.28.1.3"
+          image: "geoservercloud/geoserver-cloud-gateway:2.28.2.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -598,7 +598,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-rest:2.28.1.3"
+          image: "geoservercloud/geoserver-cloud-rest:2.28.2.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -796,7 +796,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-wcs:2.28.1.3"
+          image: "geoservercloud/geoserver-cloud-wcs:2.28.2.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -994,7 +994,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-webui:2.28.1.3"
+          image: "geoservercloud/geoserver-cloud-webui:2.28.2.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -1192,7 +1192,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-wfs:2.28.1.3"
+          image: "geoservercloud/geoserver-cloud-wfs:2.28.2.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -1390,7 +1390,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-wms:2.28.1.3"
+          image: "geoservercloud/geoserver-cloud-wms:2.28.2.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"
@@ -1598,7 +1598,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-          image: "geoservercloud/geoserver-cloud-gwc:2.28.1.3"
+          image: "geoservercloud/geoserver-cloud-gwc:2.28.2.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: "ACL_USERNAME"

--- a/values.yaml
+++ b/values.yaml
@@ -3,7 +3,7 @@ podSecurityContext: {}
 securityContext: {}
 
 common-image-stuff: &common-image-stuff
-  tag: '2.28.1.3'
+  tag: '2.28.2.0'
 
 service: &common-service-definition
   type: ClusterIP


### PR DESCRIPTION
Tests executed in context of PGConfig+ACL, with shapefile, COGs, pmtiles and geoparquet datastores.